### PR TITLE
feat(companion)!: take task text only from --prompt/--prompt-file/--stdin

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agy",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Delegate work to Google's Antigravity CLI (agy) with fast Gemini access - five personas: staffer (general), researcher, reviewer (code and plans), implementer, ask.",
   "author": {
     "name": "Keli Wen",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agy",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Delegate work to Google's Antigravity CLI (agy) with fast Gemini access - five personas: staffer (general), researcher, reviewer (code and plans), implementer, ask.",
   "author": {
     "name": "Keli Wen",

--- a/companion/agy-companion.mjs
+++ b/companion/agy-companion.mjs
@@ -11,8 +11,8 @@
  *                                   run a task as a background job (staffer is
  *                                   the general-purpose mode: a minimal prompt
  *                                   with no role or output-format framing)
- *   ask <question>                  cheap zero-tool one-shot Q&A (foreground)
- *   continue <text>                 continue the most recent conversation (any mode)
+ *   ask --prompt <question>         cheap zero-tool one-shot Q&A (foreground)
+ *   continue --prompt <text>        continue the most recent conversation (any mode)
  *   status [job-id]                 list background jobs / show one job
  *   wait [job-id] [--timeout 100s]  block until the job finishes, then print
  *                                   its result (exit 2 = still running: call
@@ -37,8 +37,16 @@
  *                         default for research/review/implement)
  *   --json                (review) ask agy for schema-enforced JSON findings
  *   --timeout <dur>       agy --print-timeout, e.g. 5m, 90s
+ *   --prompt <text>       the task text as one opaque argv value
  *   --prompt-file <path>  read the task text from a file (long prompts)
  *   --stdin               read the task text from stdin
+ *
+ * Task text for the run commands (staffer/research/review/implement/ask and
+ * continue) comes from exactly one of --prompt, --prompt-file, or --stdin.
+ * argv is parsed once, exactly as the shell delivered it, and the task value
+ * travels whole: never re-split, never scanned. Flag-like text inside a task
+ * (`--check`, `--json`, an unknown `--whatever`) is therefore ordinary prompt
+ * content and reaches agy byte for byte.
  *
  * Permissions: all tool-using modes (staffer/research/review/implement) run
  * unrestricted by default, so they work out of the box with no setup;
@@ -322,39 +330,7 @@ function pidAlive(pid) {
   }
 }
 
-/** Shell-like tokenizer so `node companion.mjs review "$ARGUMENTS"` works
- *  whether the caller passes one big string or real argv entries. */
-function tokenize(argv) {
-  const tokens = [];
-  for (const raw of argv) {
-    if (!/\s/.test(raw)) {
-      tokens.push(raw);
-      continue;
-    }
-    let cur = '';
-    let quote = null;
-    let has = false;
-    for (const ch of raw) {
-      if (quote) {
-        if (ch === quote) quote = null;
-        else { cur += ch; }
-      } else if (ch === '"' || ch === "'") {
-        quote = ch;
-        has = true;
-      } else if (/\s/.test(ch)) {
-        if (cur || has) tokens.push(cur);
-        cur = '';
-        has = false;
-      } else {
-        cur += ch;
-      }
-    }
-    if (cur || has) tokens.push(cur);
-  }
-  return tokens.filter((t) => t !== '');
-}
-
-const VALUE_FLAGS = new Set(['conversation', 'model', 'effort', 'timeout', 'restrict', 'prompt-file']);
+const VALUE_FLAGS = new Set(['conversation', 'model', 'effort', 'timeout', 'restrict', 'prompt', 'prompt-file']);
 const BOOL_FLAGS = new Set(['continue', 'restricted', 'unrestricted', 'json', 'apply', 'dry-run', 'stdin']);
 
 // Flags dropped in 0.2. They get their own error instead of falling through to
@@ -370,7 +346,7 @@ function migrationDie(name) {
   if (REMOVED_REVIEW_FLAGS.has(name)) {
     die(
       `--${name} was removed in 0.2: review is prompt-based now. Describe the subject in the prompt, ` +
-        `e.g. \`review "Review PR #730"\` or \`review "Review changes against master"\`.`
+        `e.g. \`review --prompt "Review PR #730"\` or \`review --prompt "Review changes against master"\`.`
     );
   }
   die(
@@ -379,10 +355,52 @@ function migrationDie(name) {
   );
 }
 
-function parseFlags(tokens) {
+/** A flag name that still contains whitespace means the caller packed several
+ *  arguments (and usually the task) into one quoted string. The companion does
+ *  not split argument strings, so say so and name the fix. */
+function packedArgumentDie(name, raw) {
+  const first = name.split(/\s+/)[0] || '';
+  const shown = raw.length > 60 ? `${raw.slice(0, 60)}…` : raw;
+  die(
+    `unknown flag --${first}: the whole string "${shown}" arrived as a single argument. ` +
+      `agy-staff parses argv exactly as the shell delivers it and never splits an argument into flags — ` +
+      `pass each flag as its own argument and put the task text in --prompt, ` +
+      `e.g. \`review --restricted --prompt "Review PR #730"\`.`
+  );
+}
+
+/** Reject a value flag whose value is missing, empty, or itself flag-shaped.
+ *  An empty value is a caller mistake worth surfacing rather than a default
+ *  request, and a flag-shaped value almost always means the value was
+ *  forgotten (`ask --prompt --json`). The one exception is
+ *  --prompt with a value containing whitespace: that is a real sentence that
+ *  happens to start with `--`, and prompt bytes are never second-guessed. */
+function checkValue(name, v) {
+  if (v === undefined || v === '') die(`flag --${name} needs a value`);
+  if (!v.startsWith('--')) return;
+  if (name === 'prompt') {
+    if (/\s/.test(v)) return;
+    die(
+      `flag --prompt needs a value (if your prompt really starts with --, ` +
+        `quote the full sentence or use --prompt-file)`
+    );
+  }
+  die(`flag --${name} needs a value`);
+}
+
+/**
+ * Parse the shell's argv once. Values are taken verbatim: nothing is re-split,
+ * no quotes are interpreted, no byte of a value is inspected for flags.
+ *
+ * `taskCommand` only changes what a positional means. Run commands take their
+ * task from --prompt/--prompt-file/--stdin, so a positional there is a caller
+ * mistake and dies loudly. Management commands (status/wait/result/cancel/
+ * setup) keep collecting positionals as ids and values.
+ */
+function parseFlags(argv, { taskCommand = false } = {}) {
   const opts = { _: [] };
-  for (let i = 0; i < tokens.length; i++) {
-    const t = tokens[i];
+  for (let i = 0; i < argv.length; i++) {
+    const t = argv[i];
     if (t.startsWith('--')) {
       let name = t.slice(2);
       if (REMOVED_REVIEW_FLAGS.has(name) || REMOVED_EXEC_FLAGS.has(name)) migrationDie(name);
@@ -394,14 +412,21 @@ function parseFlags(tokens) {
         name = FLAG_ALIASES[name];
       }
       if (VALUE_FLAGS.has(name)) {
-        const v = tokens[++i];
-        if (v === undefined) die(`flag --${name} needs a value`);
+        const v = argv[++i];
+        checkValue(name, v);
         opts[name] = v;
       } else if (BOOL_FLAGS.has(name)) {
         opts[name] = true;
+      } else if (/\s/.test(name)) {
+        packedArgumentDie(name, t);
       } else {
         die(`unknown flag --${name}`);
       }
+    } else if (taskCommand) {
+      die(
+        `positional task text was removed; pass the task with --prompt <text>, ` +
+          `--prompt-file <path>, or --stdin`
+      );
     } else {
       opts._.push(t);
     }
@@ -689,17 +714,19 @@ function resolveRun(mode, opts) {
   return { mode, model, profile, profileSource, background, timeout, conversation };
 }
 
-/** Task text comes from exactly one source: inline argv, --prompt-file, or
- *  --stdin. Long prompts should use the latter two instead of shell quoting. */
+/** Task text comes from exactly one source: --prompt, --prompt-file, or
+ *  --stdin. Long prompts should use the latter two instead of shell quoting.
+ *  Whatever the source, the contents are opaque here: already a single string
+ *  by the time they arrive, and never scanned for companion flags. */
 function taskText(opts) {
-  const inline = opts._.join(' ').trim();
   const sources = [
-    inline && 'inline text',
-    opts['prompt-file'] && '--prompt-file',
+    opts.prompt !== undefined && '--prompt',
+    opts['prompt-file'] !== undefined && '--prompt-file',
     opts.stdin && '--stdin',
   ].filter(Boolean);
   if (sources.length > 1) die(`task text given more than one way (${sources.join(', ')}) — use exactly one`);
-  if (opts['prompt-file']) {
+  if (opts.prompt !== undefined) return opts.prompt.trim();
+  if (opts['prompt-file'] !== undefined) {
     try {
       return fs.readFileSync(opts['prompt-file'], 'utf8').trim();
     } catch (e) {
@@ -713,7 +740,7 @@ function taskText(opts) {
       die(`cannot read task text from stdin: ${e.message}`);
     }
   }
-  return inline;
+  return '';
 }
 
 function buildPrompt(mode, opts) {
@@ -724,7 +751,7 @@ function buildPrompt(mode, opts) {
     if (mode === 'ask') die('ask needs a question');
     if (mode === 'review') {
       die(
-        'review needs a subject description, e.g. review "Review PR #730" or review "Review the current working tree"'
+        'review needs a subject description, e.g. review --prompt "Review PR #730" or review --prompt "Review the current working tree"'
       );
     }
     die(`${mode} needs a task description`);
@@ -1357,16 +1384,18 @@ function main() {
   const [cmd, ...rest] = process.argv.slice(2);
   if (!cmd) {
     die(
-      'usage: agy-companion.mjs <staffer|research|review|implement|ask|continue|status|wait|result|cancel|setup> [flags] [task]\n' +
+      'usage: agy-companion.mjs <staffer|research|review|implement|ask|continue|status|wait|result|cancel|setup> [flags]\n' +
         'flags: --restricted|--unrestricted --model <id> --effort <l|m|h> --timeout <dur> ' +
-        '--prompt-file <path> --stdin --conversation <id> --continue --json (review) ' +
+        '--prompt <text> --prompt-file <path> --stdin --conversation <id> --continue --json (review) ' +
         '--apply --restrict <modes|none> (setup)\n' +
+        'task text for staffer/research/review/implement/ask/continue comes from exactly one of ' +
+        '--prompt <text>, --prompt-file <path>, or --stdin.\n' +
         'staffer/research/review/implement run unrestricted by default (no setup needed); --restricted is the ' +
         'hardening opt-in that uses the evidence-gathering allowlist from `setup`. ask is always tool-free. ' +
         'Per-repo policy: `setup --restrict review,research` makes those modes restricted by default here.'
     );
   }
-  const opts = parseFlags(tokenize(rest));
+  const opts = parseFlags(rest, { taskCommand: MODES.includes(cmd) || cmd === 'continue' });
 
   if (MODES.includes(cmd)) return cmdRun(cmd, opts);
   switch (cmd) {

--- a/docs/INSTALL_FOR_AGENTS.md
+++ b/docs/INSTALL_FOR_AGENTS.md
@@ -70,7 +70,7 @@ If you cannot restart the session, call the companion of the freshly installed c
 
 ```bash
 AGY_ROOT=$(node -p 'require(process.env.HOME+"/.claude/plugins/installed_plugins.json").plugins["agy@agy-staff"][0].installPath')
-node "$AGY_ROOT/companion/agy-companion.mjs" ask "reply with OK"
+node "$AGY_ROOT/companion/agy-companion.mjs" ask --prompt "reply with OK"
 ```
 
 Resolve the root that way rather than globbing `cache/agy-staff/agy/*/`: superseded version directories are left behind after an upgrade, so the glob expands to several paths and the command fails with `unknown subcommand`. `installPath` is always the copy in use. (Codex's equivalent root is printed by `codex plugin list`.) A fallback pass still leaves the restart outstanding — report it as "installed and verified, restart Claude Code to use it".

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -113,20 +113,43 @@ Caveat, stated plainly: **the exact project-settings file path is undocumented a
 | `--restrict <modes\|none>` | (setup) per-repo policy: the listed modes default to restricted in this repository; `none` clears it. See [Per-repo policy](#per-repo-policy-setup---restrict) |
 | `--json` | (review) schema-enforced JSON findings; default is free-form markdown. Meant for the code-review flavor |
 | `--timeout <dur>` | agy `--print-timeout` (defaults: 10m staffer/research/implement, 5m review, 2m ask) |
+| `--prompt <text>` | the task text as one argument. Quote it; whatever is inside is opaque |
 | `--prompt-file <path>` | read the task text from a file — for long prompts, instead of shell quoting |
-| `--stdin` | read the task text from stdin. Exactly one task source per call: inline text, `--prompt-file`, or `--stdin` |
+| `--stdin` | read the task text from stdin. Exactly one task source per call: `--prompt`, `--prompt-file`, or `--stdin` |
 
 That table is the whole public surface. There is no flag for execution style — see the modes table above.
+
+## Task text
+
+This section is about the **companion CLI**, not about how you invoke a persona. You type your task as plain text after the slash command (`/agy:reviewer Review PR #730`); the skill reads it and composes the `--prompt` call below. You never type `--prompt` yourself.
+
+Every run command (`staffer`, `research`, `review`, `implement`, `ask`, `continue`) takes its task from **exactly one** of three sources:
+
+```
+ask       --prompt "what does git diff --check verify?"
+research  --prompt-file /tmp/task.md
+review    --stdin < /tmp/task.md
+```
+
+Giving two at once is an error (`task text given more than one way (…) — use exactly one`), and giving none is an error too.
+
+**The opacity guarantee.** The companion parses the shell's argv once, exactly as the shell delivered it: it re-splits no argument, interprets no quotes, and inspects no byte of a task value. Your task reaches agy byte for byte — whitespace, quotes and newlines included — and flag-like text inside it (`--check`, `--json`, `--timeout`, an unknown `--whatever`) is prompt content, never a companion option. The same holds for `--prompt-file` and `--stdin` contents.
+
+`--prompt` accepts a value that starts with `--` when it is a real sentence, meaning one that contains whitespace: `ask --prompt "--check means what?"` works. A flag-shaped value with no whitespace reads as a forgotten value and is rejected. `--` itself carries no special meaning; it parses as an unknown flag.
+
+Value flags (`--conversation`, `--model`, `--effort`, `--timeout`, `--restrict`, `--prompt`, `--prompt-file`) require a value. A missing one, an empty one, and — apart from the `--prompt` sentences above — a flag-shaped one are all errors, so `--model ""` is an error.
+
+Each flag is its own argument. Flags packed into a single quoted string (`review "--restricted Review PR #730"`) are an error that names the fix rather than a guess at where the flags end and the task begins.
 
 ## Review is prompt-based
 
 `review` takes a subject description and gathers the evidence itself with the tools it has (`gh pr view`/`gh pr diff` for PRs, `git diff`/`git log` for refs and the working tree, reading files for patches). There is no flag that hands it a diff; describe the subject in the prompt instead:
 
 ```
-review "Review PR #730"
-review "Review the current working tree"
-review "Review changes against master"
-review "Review the patch at /tmp/change.patch"
+review --prompt "Review PR #730"
+review --prompt "Review the current working tree"
+review --prompt "Review changes against master"
+review --prompt "Review the patch at /tmp/change.patch"
 ```
 
 An empty task string is an error — `review` needs a subject. If the subject is ambiguous, agy is instructed to report the ambiguity rather than guess at what you meant.
@@ -163,6 +186,7 @@ Automatic since 0.4: when the companion creates `.agy-staff/` for the first time
 - **"agy reported an error (status ERROR)"** — the companion relays agy's own error verbatim, and appends a cause hint only when the error text actually matches one (invalid model id → run `agy models`; expired auth → run `agy` interactively once to re-login; exhausted quota). If agy reported an error but still returned a complete response (e.g. one tool call timed out during wrap-up), the companion delivers the response anyway — exit 0, response on stdout, warning on stderr (`done_with_warnings`); only a run with no response fails.
 - **`operation not permitted` on `~/.gemini/...` / `bind: operation not permitted` / sudden "authentication failed" while `agy` works fine in your terminal** — agy was launched inside a harness command sandbox (typically Codex's workspace-write). agy cannot run sandboxed: it binds a localhost port for its internal language server and reads its OAuth token file, and sandbox secret-protection hides that token no matter which `writable_roots`/`network_access` knobs you open. Run companion commands unsandboxed — in Codex, grant the workspace full access or approve the command with escalated permissions.
 - **Empty response, "status SUCCESS"** — only happens on a restricted run (`--restricted`, or a project policy that restricts the mode): agy reports success even when every tool call was denied, so the content is empty and stderr carries a permission note. The companion detects this and tells you the fix: run `setup` once so the allowlist exists, or relax the profile (drop `--restricted`, or `setup --restrict none` if it came from the policy). Caveat baked into agy: some tools ignore allow-rules in headless mode entirely and only work with the skip flag — those always need an unrestricted run. (`ask` cannot hit this case; if it does, report a bug.)
+- **"unknown flag --X: the whole string … arrived as a single argument"** — several flags, and usually the task, are quoted into one argument. Each flag is its own argument; the task belongs in `--prompt`. See [Task text](#task-text).
 - **"task text exceeds the 200KB inline limit"** — the whole prompt travels to agy as one argv entry and macOS ARG_MAX is ~1MB (agy itself does not read stdin, so `--prompt-file`/`--stdin` only fix shell quoting, not this ceiling). Shorten the task text: point agy at the material (a PR number, a ref, a file path) and let it fetch the content itself instead of pasting it in.
 - **Never use agy's `--sandbox` for these modes** — it redirects execution into agy's own scratch workspace (`~/.gemini/antigravity-cli/scratch`) and cannot see your real working directory. The companion never passes it.
 - **Dirty workspace on implement** — `implement` can start even when the repo already has changes. The companion adds a capped status summary to agy's prompt so it knows those paths are pre-existing user work. If the task does not clearly include them, agy should ask before overwriting, cleaning, stashing, resetting, deleting, committing, pushing, or opening a PR with those changes.
@@ -180,9 +204,9 @@ Automatic since 0.4: when the companion creates `.agy-staff/` for the first time
 | `--strict` | `--restricted` | Old name still accepted for one release; it warns on stderr. Same semantics. |
 | `--loose` | `--unrestricted` | Old name still accepted for one release; it warns on stderr. Same semantics. |
 | profile names "strict"/"loose" in output | "restricted"/"unrestricted" | Cosmetic rename; the telemetry line (stderr) now prints `profile=restricted` / `profile=unrestricted`. |
-| `--diff-file <path>` | *(removed)* | Review is prompt-based: `review "Review the patch at /tmp/change.patch"`. |
-| `--pr <num>` | *(removed)* | `review "Review PR #730"`. |
-| `--target <ref>` | *(removed)* | `review "Review changes against master"`. |
+| `--diff-file <path>` | *(removed)* | Review is prompt-based: `review --prompt "Review the patch at /tmp/change.patch"`. |
+| `--pr <num>` | *(removed)* | `review --prompt "Review PR #730"`. |
+| `--target <ref>` | *(removed)* | `review --prompt "Review changes against master"`. |
 | `--background` / `--wait` | *(removed)* | Execution style is fixed per mode: `ask` is synchronous, `research`/`review`/`implement` return a job id. Manage them with `status`/`result`/`cancel`. |
 
 Removed flags fail fast with a message naming the replacement; the deprecated profile aliases keep working through this release and will be deleted in the next one.
@@ -200,6 +224,17 @@ Removed flags fail fast with a message naming the replacement; the deprecated pr
 | *(none)* | `/agy:staffer` | new general-purpose mode with a minimal prompt |
 | `/agy:status`, `/agy:wait`, `/agy:result`, `/agy:cancel`, `/agy:continue`, `/agy:setup` | the `jobs` skill (model-facing) | ask in natural language ("is the agy job done?"); the companion subcommands are unchanged |
 | manual `.git/info/exclude` step | automatic on first run | |
+
+## Migration from 0.4.4 (breaking)
+
+0.4.5 removes positional task text. The companion parses the shell's argv once and never re-splits an argument, which is what makes flag-like text inside a task safe (see [Task text](#task-text)). The price is that the task must arrive through an explicit source.
+
+| 0.4.4 | 0.4.5 | Notes |
+|---|---|---|
+| `ask "question"`, `review "Review PR #730"` (positional task text) | `ask --prompt "question"`, `review --prompt "Review PR #730"` | Positional text is removed, not deprecated: a positional argument on a run command is an error naming the three sources. `--prompt-file` and `--stdin` are unchanged. |
+| one big string, e.g. `review "--restricted Review PR #730"` | `review --restricted --prompt "Review PR #730"` | The companion no longer splits an argument into flags. A flag name that still contains whitespace gets an error naming this fix. |
+
+Management commands (`status`, `wait`, `result`, `cancel`, `setup`) are untouched: their positional arguments are ids and values, and `wait <id> --timeout 30s` works exactly as before.
 
 ## Upgrading
 

--- a/docs/REFERENCE.zh-CN.md
+++ b/docs/REFERENCE.zh-CN.md
@@ -113,20 +113,43 @@ policy 写入 `<repo>/.agy-staff/config.json`，之后自动生效（运行时�
 | `--restrict <modes\|none>` | （setup）仓库级 policy：列出的模式在本仓库默认 restricted；`none` 清除。见[仓库级 policy](#仓库级-policysetup---restrict) |
 | `--json` | （review）按 schema 强制输出 JSON findings；默认是自由格式 markdown。面向代码审查 flavor |
 | `--timeout <dur>` | agy 的 `--print-timeout`（默认：staffer/research/implement 10m，review 5m，ask 2m） |
+| `--prompt <text>` | 任务正文，作为**一个**参数传入。请加引号；引号里的内容一律不透明 |
 | `--prompt-file <path>` | 从文件读任务文本——长 prompt 用它，不用跟 shell 引号搏斗 |
-| `--stdin` | 从 stdin 读任务文本。每次调用只允许一个任务来源：内联文本、`--prompt-file` 或 `--stdin` |
+| `--stdin` | 从 stdin 读任务文本。每次调用只允许一个任务来源：`--prompt`、`--prompt-file` 或 `--stdin` |
 
 这张表就是全部对外接口。执行方式没有对应 flag——见上面的模式表。
+
+## 任务正文
+
+这一节讲的是 **companion CLI**，不是人格的调用方式。你在斜杠命令后面直接写自然语言任务（`/agy:reviewer Review PR #730`）；skill 会读它，再组装成下面的 `--prompt` 调用。`--prompt` 不需要你自己写。
+
+所有运行类命令（`staffer`、`research`、`review`、`implement`、`ask`、`continue`）的任务正文来自三个来源中的**恰好一个**：
+
+```
+ask       --prompt "what does git diff --check verify?"
+research  --prompt-file /tmp/task.md
+review    --stdin < /tmp/task.md
+```
+
+同时给两个是错误（`task text given more than one way (…) — use exactly one`），一个都不给也是错误。
+
+**不透明性保证。** companion 只解析一次 shell 交给它的 argv，且完全按照 shell 交付的样子：不切分任何一个参数，不解释引号，也不检查任务正文里的任何一个字节。你的任务正文会逐字节送到 agy——空白、引号、换行全部保留——其中形似 flag 的文本（`--check`、`--json`、`--timeout`，乃至未知的 `--whatever`）就是 prompt 内容，而不是 companion 选项。`--prompt-file` 和 `--stdin` 的内容同理。
+
+当 `--prompt` 的值是一个真正的句子（即含有空白）时，它可以以 `--` 开头：`ask --prompt "--check means what?"` 是有效的。不含任何空白、形似 flag 的值会被读作「忘了写值」并拒绝。`--` 本身没有特殊含义，它会被当作未知 flag 解析。
+
+带值的 flag（`--conversation`、`--model`、`--effort`、`--timeout`、`--restrict`、`--prompt`、`--prompt-file`）都需要一个值。缺失的值、空字符串值，以及形似 flag 的值（`--prompt` 的整句情况除外，见上）都是错误，所以 `--model ""` 是错误。
+
+每个 flag 都是独立的一个参数。多个 flag 被打包进同一个引号字符串（`review "--restricted Review PR #730"`）是错误，companion 会直接给出修法，而不是去猜 flag 在哪里结束、任务从哪里开始。
 
 ## review 完全基于 prompt
 
 `review` 接受一段「审查对象」的描述，然后自己去收集证据（PR 用 `gh pr view`/`gh pr diff`，ref 和工作区用 `git diff`/`git log`，补丁则直接读文件）。没有任何 flag 可以直接传入 diff；请在 prompt 里描述对象：
 
 ```
-review "Review PR #730"
-review "Review the current working tree"
-review "Review changes against master"
-review "Review the patch at /tmp/change.patch"
+review --prompt "Review PR #730"
+review --prompt "Review the current working tree"
+review --prompt "Review changes against master"
+review --prompt "Review the patch at /tmp/change.patch"
 ```
 
 任务描述为空是错误——`review` 必须有审查对象。若对象有歧义，模板要求 agy 报告这个歧义，而不是猜你想审什么。
@@ -163,6 +186,7 @@ review 模板本身是中性骨架（审查者立场、证据纪律、护栏）�
 - **"agy reported an error (status ERROR)"** — companion 会原样转述 agy 自己的报错，且只在错误文本确实匹配时才追加原因提示（模型 id 无效 → 运行 `agy models`；登录过期 → 交互式运行一次 `agy` 重新登录；额度用尽）。如果 agy 报了错但完整的 response 已经产出（例如收尾时一次工具调用超时），companion 会照常交付：退出码 0，response 走 stdout，警告走 stderr（`done_with_warnings`）——只有没有 response 的运行才算失败。
 - **`~/.gemini/...` 上的 `operation not permitted` / `bind: operation not permitted` / 终端里 `agy` 明明正常却突然"authentication failed"** — agy 被放进了 harness 的命令沙箱里执行（典型是 Codex 的 workspace-write）。agy 无法在沙箱内运行：它要为内部 language server 绑定 localhost 端口、还要读自己的 OAuth token 文件，而沙箱的凭据保护会直接把 token 藏起来——无论开多少 `writable_roots`/`network_access` 都救不回来。companion 命令必须在沙箱外执行——Codex 里给该 workspace 授予 full access，或以 escalated 权限批准命令。
 - **空响应但 "status SUCCESS"** — 只会出现在 restricted 档的运行里（传了 `--restricted`，或项目 policy 把该模式设成了 restricted）：即使所有工具调用都被拒绝，agy 也会报 success；此时内容为空、stderr 带权限提示。companion 会检测到并给出修复方式：跑一次 `setup` 把 allowlist 装上，或者放宽权限档（去掉 `--restricted`；来自 policy 的话用 `setup --restrict none`）。另有一个 agy 自身的限制：部分工具在 headless 下完全无视 allow-rules，只在跳过权限时可用——这类操作永远需要 unrestricted 的运行。（`ask` 不可能触发此情况；若触发请报 bug。）
+- **"unknown flag --X: the whole string … arrived as a single argument"** — 多个 flag（通常还带着任务正文）被引号打包成了一个参数。每个 flag 都要作为独立参数传，任务正文放进 `--prompt`。见[任务正文](#任务正文)。
 - **"task text exceeds the 200KB inline limit"** — 整个 prompt 作为单个 argv 传给 agy，macOS 的 ARG_MAX 约 1MB（agy 自己不读 stdin，所以 `--prompt-file`/`--stdin` 只解决 shell 引号问题，解决不了这个上限）。请缩短任务描述：把材料的位置（PR 号、ref、文件路径）指给 agy，让它自己去取内容，而不是整段粘进来。
 - **这些模式绝不要用 agy 的 `--sandbox`** — 它会把执行重定向到 agy 自己的 scratch 工作区（`~/.gemini/antigravity-cli/scratch`），看不到你真实的工作目录。companion 从不传该参数。
 - **implement 遇到 dirty workspace** — 即使仓库里已经有改动，`implement` 也可以启动。companion 会把一份有长度上限的状态摘要加进 agy 的 prompt，让它知道这些路径是用户已有改动。若任务没有明确包含这些改动，agy 应先询问，再决定是否覆盖、清理、stash、reset、删除、commit、push，或把它们放进 PR。
@@ -180,9 +204,9 @@ review 模板本身是中性骨架（审查者立场、证据纪律、护栏）�
 | `--strict` | `--restricted` | 旧名保留一个版本仍可用，会在 stderr 打印一次弃用提示。语义不变。 |
 | `--loose` | `--unrestricted` | 旧名保留一个版本仍可用，会在 stderr 打印一次弃用提示。语义不变。 |
 | 输出中的权限档名 "strict"/"loose" | "restricted"/"unrestricted" | 纯改名；telemetry 行（stderr）现在打印 `profile=restricted` / `profile=unrestricted`。 |
-| `--diff-file <path>` | *（已移除）* | review 改为基于 prompt：`review "Review the patch at /tmp/change.patch"`。 |
-| `--pr <num>` | *（已移除）* | `review "Review PR #730"`。 |
-| `--target <ref>` | *（已移除）* | `review "Review changes against master"`。 |
+| `--diff-file <path>` | *（已移除）* | review 改为基于 prompt：`review --prompt "Review the patch at /tmp/change.patch"`。 |
+| `--pr <num>` | *（已移除）* | `review --prompt "Review PR #730"`。 |
+| `--target <ref>` | *（已移除）* | `review --prompt "Review changes against master"`。 |
 | `--background` / `--wait` | *（已移除）* | 执行方式按模式固定：`ask` 同步，`research`/`review`/`implement` 返回 job id，用 `status`/`result`/`cancel` 管理。 |
 
 已移除的 flag 会立即报错并在错误信息里给出替代写法；弃用的权限档别名在本版本内继续可用，下个版本删除。
@@ -200,6 +224,17 @@ review 模板本身是中性骨架（审查者立场、证据纪律、护栏）�
 | *（无）* | `/agy:staffer` | 新增的通用模式，最小化 prompt |
 | `/agy:status`、`/agy:wait`、`/agy:result`、`/agy:cancel`、`/agy:continue`、`/agy:setup` | `jobs` skill（面向模型） | 用自然语言（「agy 的 job 好了吗」）；companion 子命令本身不变 |
 | 手动写 `.git/info/exclude` | 首次运行自动完成 | |
+
+## 从 0.4.4 迁移（破坏性变更）
+
+0.4.5 移除了 positional 任务正文。companion 只解析一次 shell 交给它的 argv，且绝不重新切分参数——正是这一点让任务正文里形似 flag 的文本变得安全（见[任务正文](#任务正文)）。代价是任务必须通过一个显式来源传入。
+
+| 0.4.4 | 0.4.5 | 说明 |
+|---|---|---|
+| `ask "question"`、`review "Review PR #730"`（positional 任务正文） | `ask --prompt "question"`、`review --prompt "Review PR #730"` | positional 正文是移除而不是弃用：运行类命令上出现 positional 参数会直接报错，并指出三个来源。`--prompt-file` 与 `--stdin` 不变。 |
+| 打包成一个大字符串，如 `review "--restricted Review PR #730"` | `review --restricted --prompt "Review PR #730"` | companion 不再把一个参数切分成多个 flag。若某个 flag 名里仍含空白，会得到一条指向此修法的错误。 |
+
+管理类命令（`status`、`wait`、`result`、`cancel`、`setup`）不受影响：它们的 positional 参数是 id 和取值，`wait <id> --timeout 30s` 与之前完全一致。
 
 ## 升级
 

--- a/docs/releases/v0.4.5.md
+++ b/docs/releases/v0.4.5.md
@@ -1,0 +1,43 @@
+# agy-staff 0.4.5 — Opaque Task Text
+
+Release date: _unreleased_. This note is the canonical record for 0.4.5; the GitHub Release mirrors it.
+
+## Highlights
+
+- **Flag-like text inside a task is finally safe.** A prompt mentioning `git diff --check` used to die with `agy-staff error: unknown flag --check`. The companion tokenized task text twice: the shell had already split argv, then `tokenize()` re-split any entry containing whitespace and the flag parser scanned every resulting token. Now argv is parsed once, exactly as the shell delivered it — no argument is re-split, no quotes are interpreted, and no byte of a task value is inspected. `--check`, `--json`, `--timeout`, an unknown `--whatever` inside a task are prompt content and reach agy verbatim (#3).
+- **Task text has three explicit sources**, and exactly one per call: `--prompt <text>`, `--prompt-file <path>`, or `--stdin`. `--prompt-file` and `--stdin` contents were never scanned and still are not.
+- **Value flags reject a value that is not one.** A missing value, an empty value, or a flag-shaped value is now an error. `--model ""` no longer falls back to the default silently, and `ask --prompt --json` is caught as a forgotten value rather than dispatched as an empty prompt.
+
+## Breaking changes
+
+Positional task text is removed, and so is one-big-string flag parsing. Both failure modes are loud and name the replacement — nothing degrades silently.
+
+| 0.4.4 | 0.4.5 |
+|---|---|
+| `ask "question"`, `review "Review PR #730"` | `ask --prompt "question"`, `review --prompt "Review PR #730"` |
+| `review "--restricted Review PR #730"` (flags packed into one quoted string) | `review --restricted --prompt "Review PR #730"` |
+
+A positional argument on a run command — including the empty string that `--prompt "$Q" "$EXTRA"` produces when `$EXTRA` is unset — exits with `positional task text was removed; pass the task with --prompt <text>, --prompt-file <path>, or --stdin`. There is no deprecation window and no `--` sentinel: `--` is just an unknown flag. A `--prompt` value that starts with `--` is still accepted when it is a real sentence (it contains whitespace), so `ask --prompt "--check means what?"` works.
+
+This is a change to the **companion CLI**, not to how you invoke the personas. `/agy:ask reply with OK` is unchanged: you still type your question as plain text after the slash command, and the skill composes the `--prompt` call for you.
+
+Management commands (`status`, `wait`, `result`, `cancel`, `setup`) are untouched — their positional arguments are ids and values, and `wait <id> --timeout 30s` behaves exactly as before. Full table with notes: [REFERENCE.md → Migration from 0.4.4](../REFERENCE.md#migration-from-044-breaking).
+
+## Verification
+
+- Added black-box coverage for the task-source contract: opaque flag-like prompts in a foreground `ask` and a background `review`, the same through `--prompt-file` and `--stdin`, byte-exact prompt fidelity through quotes/newlines/double spaces, both source-conflict pairs, the removed positional path (a plain word and an empty string), packed one-big-string arguments, `--` having no special meaning, the value-flag guards, and a management-command regression (`wait <id> --timeout`, `status`, `setup --restrict`).
+- Full suite: 110 tests, 0 failures.
+
+## Upgrading
+
+Both harnesses install a copy — pull 0.4.5 in yourself, then restart the harness so the skills load:
+
+```bash
+claude plugin marketplace update agy-staff && claude plugin update agy@agy-staff   # then restart Claude Code
+```
+
+```bash
+codex plugin marketplace upgrade && codex plugin add agy@agy-staff                 # then restart Codex
+```
+
+If you drive the companion CLI directly from scripts or your own tooling, move task text to `--prompt` before upgrading.

--- a/skills/ask/SKILL.md
+++ b/skills/ask/SKILL.md
@@ -7,7 +7,7 @@ allowed-tools: Bash(node:*)
 
 # agy ask
 
-The quick mode: one question in, one answer out, ~3 seconds on the default `gemini-3.7-flash-low`. Zero tools by design (restricted profile, question-only prompt), so it needs no setup and works on a fresh install — run it first as the smoke test: `ask "reply with OK"`.
+The quick mode: one question in, one answer out, ~3 seconds on the default `gemini-3.7-flash-low`. Zero tools by design (restricted profile, question-only prompt), so it needs no setup and works on a fresh install — run it first as the smoke test: `ask --prompt "reply with OK"`.
 
 ask is the only persona that runs in the foreground: the call blocks and the answer comes back on stdout. staffer, researcher, reviewer, and implementer instead return a background job id (see the jobs skill, `../jobs/SKILL.md`).
 
@@ -16,14 +16,17 @@ ask is the only persona that runs in the foreground: the call blocks and the ans
 This skill file lives at `<plugin-root>/skills/ask/SKILL.md`; resolve the companion path relative to this skill directory:
 
 ```bash
-node "<skill-dir>/../../companion/agy-companion.mjs" ask [flags] "question"
+node "<skill-dir>/../../companion/agy-companion.mjs" ask [flags] --prompt "question"
 ```
+
+Pass the user's question verbatim via `--prompt`; use `--prompt-file <path>` or `--stdin` for a long question.
 
 > [!IMPORTANT]
 > Run this command **unsandboxed** — agy needs a localhost port and its OAuth token file, which harness sandboxes hide. In Codex, request escalated permissions for the command. Details: `../jobs/references/troubleshooting.md`.
 
 ## Flags (all optional)
 
+- `--prompt <text>` / `--prompt-file <path>` / `--stdin` — the question, from exactly one of these three sources. Use file/stdin for a long question.
 - `--continue` — reuse the last ask conversation; `--conversation <id>` targets a specific one.
 - `--model <id>` or `--effort low|medium|high` — default model is `gemini-3.7-flash-low`.
 - `--timeout <dur>` — default 2m.

--- a/skills/implementer/SKILL.md
+++ b/skills/implementer/SKILL.md
@@ -14,8 +14,10 @@ Hand a coding task to the agy staffer. agy edits the real working tree under its
 This skill file lives at `<plugin-root>/skills/implementer/SKILL.md`; resolve the companion path relative to this skill directory:
 
 ```bash
-node "<skill-dir>/../../companion/agy-companion.mjs" implement [flags] "task description"
+node "<skill-dir>/../../companion/agy-companion.mjs" implement [flags] --prompt "task description"
 ```
+
+Pass the user's task description verbatim via `--prompt`; use `--prompt-file <path>` or `--stdin` for long text.
 
 > [!IMPORTANT]
 > Run this command **unsandboxed** — agy needs a localhost port and its OAuth token file, which harness sandboxes hide. In Codex, request escalated permissions for the command. Details: `../jobs/references/troubleshooting.md`. (The companion passes `--dangerously-skip-permissions` to agy in this mode — that is the unrestricted profile working as designed.)
@@ -39,7 +41,7 @@ The job-start output prints the exact collect command (`` `wait <id> --timeout <
 
 - `--restricted` / `--unrestricted` — permission profile. implement defaults to unrestricted, so it works out of the box with no setup. `--restricted` is the opt-in hardening path: agy may then only use allowlisted tools, so it can usually only propose rather than edit, and it needs the setup flow's evidence-gathering allowlist to be useful.
 - `--continue` (or `--conversation <id>`), `--model <id>` / `--effort low|medium|high` (default `gemini-3.7-flash-high`), `--timeout <dur>` (default 10m).
-- `--prompt-file <path>` / `--stdin` — task text from a file or stdin (long prompts).
+- `--prompt <text>` / `--prompt-file <path>` / `--stdin` — the task, from exactly one of these three sources. Use file/stdin for long prompts.
 
 ## Rules
 

--- a/skills/jobs/SKILL.md
+++ b/skills/jobs/SKILL.md
@@ -37,7 +37,7 @@ Delivering an exit-0 result: a short report (about a screenful) → verbatim; a 
 - **status `[job-id]`** — list jobs (render as a compact table) or show one job with a log tail; with an id it exits with the same codes as `wait`.
 - **result `[job-id]`** — re-print the stored output of a finished job (default: the most recent finished one). Deliver per "Collecting results".
 - **cancel `<job-id>`** — kill a running job and mark it canceled.
-- **continue `"follow-up text"`** — send a follow-up to the most recent agy conversation in this repo (any mode; quota-friendly — agy serves prior context from cache). `--conversation <id>` targets an older one; ids are tracked in `.agy-staff/state.json` and shown on the `[agy-staff]` stderr line. Execution style follows the resumed mode: a continued ask is foreground, everything else returns a job id.
+- **continue `--prompt "follow-up text"`** — send a follow-up to the most recent agy conversation in this repo (any mode; quota-friendly — agy serves prior context from cache). `--conversation <id>` targets an older one; ids are tracked in `.agy-staff/state.json` and shown on the `[agy-staff]` stderr line. Execution style follows the resumed mode: a continued ask is foreground, everything else returns a job id.
 - **setup `[--apply] [--restrict <modes|none>]`** — optional hardening for restricted runs. Read `references/setup.md` before running it.
 
 ## Rules

--- a/skills/researcher/SKILL.md
+++ b/skills/researcher/SKILL.md
@@ -14,8 +14,10 @@ Delegate a research task to the agy staffer via the shared companion script. You
 This skill file lives at `<plugin-root>/skills/researcher/SKILL.md`; resolve the companion path relative to this skill directory:
 
 ```bash
-node "<skill-dir>/../../companion/agy-companion.mjs" research [flags] "what to research"
+node "<skill-dir>/../../companion/agy-companion.mjs" research [flags] --prompt "what to research"
 ```
+
+Pass the user's research topic verbatim via `--prompt`; use `--prompt-file <path>` or `--stdin` for a long brief.
 
 > [!IMPORTANT]
 > Run this command **unsandboxed** — agy needs a localhost port and its OAuth token file, which harness sandboxes hide. In Codex, request escalated permissions for the command. Details: `../jobs/references/troubleshooting.md`.
@@ -33,7 +35,7 @@ The job-start output prints the exact collect command (`` `wait <id> --timeout <
 - `--continue` — reuse the last research conversation (quota-friendly, served largely from cache); `--conversation <id>` targets a specific one.
 - `--model <id>` or `--effort low|medium|high` — default model is `gemini-3.7-flash-high`.
 - `--restricted` / `--unrestricted` — permission profile. research defaults to unrestricted, so it works out of the box with no setup. `--restricted` is the opt-in hardening path: agy runs without `--dangerously-skip-permissions` and may only use allowlisted tools, so it needs the setup flow's evidence-gathering allowlist to be useful — and some native agy tools ignore allow-rules headless, so restricted runs can still come back empty.
-- `--prompt-file <path>` / `--stdin` — task text from a file or stdin (long prompts).
+- `--prompt <text>` / `--prompt-file <path>` / `--stdin` — the task, from exactly one of these three sources. Use file/stdin for long prompts.
 - `--timeout <dur>` — default 10m.
 
 ## Rules

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -19,8 +19,10 @@ The companion's template contributes only the reviewer stance, evidence discipli
 This skill file lives at `<plugin-root>/skills/reviewer/SKILL.md`; resolve the companion path relative to this skill directory:
 
 ```bash
-node "<skill-dir>/../../companion/agy-companion.mjs" review [flags] "what to review"
+node "<skill-dir>/../../companion/agy-companion.mjs" review [flags] --prompt "what to review"
 ```
+
+Pass the review subject verbatim via `--prompt`; use `--prompt-file <path>` or `--stdin` for long text, which a composed task usually needs.
 
 > [!IMPORTANT]
 > Run this command **unsandboxed** — agy needs a localhost port and its OAuth token file, which harness sandboxes hide. In Codex, request escalated permissions for the command. Details: `../jobs/references/troubleshooting.md`.
@@ -42,7 +44,7 @@ The job-start output prints the exact collect command (`` `wait <id> --timeout <
 - `--json` — schema-enforced JSON findings (verdict/summary/findings/could_not_verify) instead of markdown. Code-review flavor only, and only when the user asks for machine-readable output.
 - `--restricted` / `--unrestricted` — permission profile. review defaults to unrestricted, so it works out of the box and can run tests or reproduce a bug when the request asks for it. `--restricted` is the opt-in hardening path: agy may then only use allowlisted tools, so it needs the setup flow's evidence-gathering allowlist to be useful — and some native agy tools ignore allow-rules headless, so restricted runs can still come back empty.
 - `--model <id>` / `--effort low|medium|high` (default `gemini-3.7-flash-medium`), `--continue` (or `--conversation <id>`), `--timeout <dur>` (default 5m).
-- `--prompt-file <path>` / `--stdin` — task text from a file or stdin (long prompts; a composed task with the flavor framing usually is one).
+- `--prompt <text>` / `--prompt-file <path>` / `--stdin` — the task, from exactly one of these three sources. Use file/stdin for long prompts (a composed task with the flavor framing usually is one).
 
 ## Reviewing untrusted content
 

--- a/skills/reviewer/references/code-review.md
+++ b/skills/reviewer/references/code-review.md
@@ -1,6 +1,6 @@
 # Composing a code-review task
 
-Read this when the review subject is code: a PR, a branch or ref, the working tree, a patch file, or specific files. The companion's template carries only the reviewer stance and guardrails; the code-review contract below travels in the task string. Compose the task as the user's request, verbatim, followed by this contract — adjusted only where the request explicitly overrides it. A composed task is usually long: pass it with `--prompt-file` or `--stdin`.
+Read this when the review subject is code: a PR, a branch or ref, the working tree, a patch file, or specific files. The companion's template carries only the reviewer stance and guardrails; the code-review contract below travels in the task string. Compose the task as the user's request, verbatim, followed by this contract — adjusted only where the request explicitly overrides it. A composed task is usually long: pass it with `--prompt-file` or `--stdin` rather than `--prompt` (the three are the only task sources, and exactly one per call).
 
 The standards and spec-alignment axes are adapted from `code-review` in [mattpocock/skills](https://github.com/mattpocock/skills) (MIT).
 

--- a/skills/staffer/SKILL.md
+++ b/skills/staffer/SKILL.md
@@ -11,15 +11,17 @@ The general-purpose persona: a clean entry point for tasks that none of the spec
 
 Prefer a specialist when one fits: `researcher` for surveys and deep dives, `reviewer` for second opinions on code or plans, `implementer` for edits to the working tree, `ask` for a cheap one-shot question.
 
-staffer is also the route to agy-native tools no specialist covers — notably **image generation**: agy ships a `generate_image` tool (verified on v1.1.15; a 1024×1024 PNG in ~30s). Name the output path in the task, e.g. `staffer "generate a pixel-art robot mascot, save it as assets/mascot.png"`.
+staffer is also the route to agy-native tools no specialist covers — notably **image generation**: agy ships a `generate_image` tool (verified on v1.1.15; a 1024×1024 PNG in ~30s). Name the output path in the task, e.g. `staffer --prompt "generate a pixel-art robot mascot, save it as assets/mascot.png"`.
 
 ## Locating the companion
 
 This skill file lives at `<plugin-root>/skills/staffer/SKILL.md`; resolve the companion path relative to this skill directory:
 
 ```bash
-node "<skill-dir>/../../companion/agy-companion.mjs" staffer [flags] "task"
+node "<skill-dir>/../../companion/agy-companion.mjs" staffer [flags] --prompt "task"
 ```
+
+Pass the user's task text verbatim via `--prompt`; use `--prompt-file <path>` or `--stdin` for long text.
 
 > [!IMPORTANT]
 > Run this command **unsandboxed** — agy needs a localhost port and its OAuth token file, which harness sandboxes hide. In Codex, request escalated permissions for the command. Details: `../jobs/references/troubleshooting.md`.
@@ -34,7 +36,7 @@ The job-start output prints the exact collect command (`` `wait <id> --timeout <
 
 ## Flags (all optional)
 
-- `--prompt-file <path>` / `--stdin` — task text from a file or stdin; use these for long prompts instead of shell quoting.
+- `--prompt <text>` / `--prompt-file <path>` / `--stdin` — the task, from exactly one of these three sources. Use file/stdin for long prompts instead of shell quoting.
 - `--model <id>` or `--effort low|medium|high` — default model is `gemini-3.7-flash-medium`.
 - `--restricted` / `--unrestricted` — permission profile; staffer defaults to unrestricted like the other tool-using personas, `--restricted` is the opt-in hardening path.
 - `--continue` (or `--conversation <id>`), `--timeout <dur>` (default 10m).

--- a/tests/README.md
+++ b/tests/README.md
@@ -49,6 +49,11 @@ setup); the output split (the `[agy-staff]` telemetry line is asserted on stderr
 for foreground runs and in `jobs/<id>.log` for background ones, and asserted
 absent from stdout and from `jobs/<id>.result.md`); prompt-based `review`; job
 lifecycle (`status`/`result`/`cancel`);
+the task-source contract (task text comes from exactly one of `--prompt`,
+`--prompt-file`, or `--stdin`; positional task text is an error; task contents
+are opaque — flag-like text inside a task never becomes a companion option, and
+prompt bytes reach the fake `agy` verbatim; value flags reject missing, empty,
+and flag-shaped values; management commands keep their positional ids);
 `continue` mode inheritance; `setup`'s dry run and its optional-hardening
 framing; and the state-file robustness fixes (`state.test.mjs`).
 

--- a/tests/dx.test.mjs
+++ b/tests/dx.test.mjs
@@ -1,18 +1,25 @@
 /**
- * DX surface added in 0.4: the staffer mode's minimal prompt, task text from
- * --prompt-file / --stdin, and first-run auto-ignore of .agy-staff/.
+ * DX surface: the staffer mode's minimal prompt, the three explicit task-text
+ * sources (--prompt / --prompt-file / --stdin) and the opacity guarantee that
+ * comes with them, the value-flag guards, and first-run auto-ignore of
+ * .agy-staff/.
+ *
+ * The opacity contract (issue #3): argv is parsed once, exactly as the shell
+ * delivered it. Once a task value is read, no byte of it is ever inspected for
+ * companion flags — `--check`, `--json`, `--timeout`, an unknown `--whatever`
+ * inside a task are prompt content, not options.
  */
 import { test, describe } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { spawnSync } from 'node:child_process';
-import { sandbox, run, jobIdOf, waitForJob, waitForCalls, promptOf } from './helpers.mjs';
+import { sandbox, run, agyCalls, jobIdOf, waitForJob, waitForCalls, promptOf } from './helpers.mjs';
 
 describe('staffer: the general-purpose mode', () => {
   test('prompt is minimal: task + environment + guardrails, no role or output framing', async () => {
     const sb = sandbox('staffer-prompt');
-    const r = run(sb, ['staffer', 'do the thing']);
+    const r = run(sb, ['staffer', '--prompt', 'do the thing']);
     assert.equal(r.code, 0, r.stderr);
     await waitForJob(sb, jobIdOf(r.stdout));
     const [argv] = await waitForCalls(sb, 1);
@@ -30,12 +37,21 @@ describe('staffer: the general-purpose mode', () => {
     const sb = sandbox('staffer-policy');
     const r = run(sb, ['setup', '--restrict', 'staffer']);
     assert.equal(r.code, 0, r.stderr);
-    const started = run(sb, ['staffer', 'a task']);
+    const started = run(sb, ['staffer', '--prompt', 'a task']);
     assert.match(started.stdout, /profile: restricted/);
   });
 });
 
 describe('task text sources', () => {
+  test('--prompt reads the task from one opaque argv value', async () => {
+    const sb = sandbox('prompt-flag');
+    const r = run(sb, ['staffer', '--prompt', 'a task passed as one argument']);
+    assert.equal(r.code, 0, r.stderr);
+    await waitForJob(sb, jobIdOf(r.stdout));
+    const [argv] = await waitForCalls(sb, 1);
+    assert.match(promptOf(argv), /a task passed as one argument/);
+  });
+
   test('--prompt-file reads the task from a file', async () => {
     const sb = sandbox('prompt-file');
     const f = path.join(sb.root, 'task.md');
@@ -63,13 +79,223 @@ describe('task text sources', () => {
     assert.match(r.stderr, /cannot read --prompt-file/);
   });
 
-  test('two task sources at once die pre-flight', () => {
+  test('--prompt with --prompt-file dies as two task sources', () => {
     const sb = sandbox('prompt-two-sources');
     const f = path.join(sb.root, 'task.md');
     fs.writeFileSync(f, 'file task\n');
-    const r = run(sb, ['staffer', '--prompt-file', f, 'inline task too']);
+    const r = run(sb, ['staffer', '--prompt-file', f, '--prompt', 'inline task too']);
     assert.notEqual(r.code, 0);
-    assert.match(r.stderr, /more than one way/);
+    assert.match(r.stderr, /task text given more than one way \(--prompt, --prompt-file\)/);
+  });
+
+  test('--prompt with --stdin dies as two task sources', () => {
+    const sb = sandbox('prompt-stdin-conflict');
+    const r = run(sb, ['staffer', '--prompt', 'flag task', '--stdin'], {}, { input: 'piped task\n' });
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /task text given more than one way \(--prompt, --stdin\)/);
+  });
+});
+
+describe('task text is opaque: flag-like content is never parsed (issue #3)', () => {
+  test('foreground ask: a prompt mentioning `git diff --check` reaches agy intact', async () => {
+    const sb = sandbox('opaque-ask');
+    const task = "please explain what git diff --check verifies and keep 'the quotes'";
+    const r = run(sb, ['ask', '--prompt', task]);
+    assert.equal(r.code, 0, r.stderr);
+    assert.doesNotMatch(r.stderr, /unknown flag/);
+    const [argv] = await waitForCalls(sb, 1);
+    assert.ok(promptOf(argv).includes(task), `prompt lost the task text: ${promptOf(argv)}`);
+  });
+
+  test('background review: known companion flag names inside the task stay content', async () => {
+    const sb = sandbox('opaque-review');
+    const task = 'Review code that mentions --json, --timeout 1s, --restricted and --whatever';
+    const r = run(sb, ['review', '--prompt', task]);
+    assert.equal(r.code, 0, r.stderr);
+    // the mode's own defaults must be untouched by the flag names in the task
+    assert.match(r.stdout, /profile: unrestricted/);
+    await waitForJob(sb, jobIdOf(r.stdout));
+    const [argv] = await waitForCalls(sb, 1);
+    assert.ok(promptOf(argv).includes(task), `prompt lost the task text: ${promptOf(argv)}`);
+    assert.ok(!argv.includes('--json-schema'), '--json inside the task must not enable the schema');
+    assert.equal(argv[argv.indexOf('--print-timeout') + 1], '5m', "review's default timeout must hold");
+  });
+
+  test('--prompt-file content containing companion flags is never scanned', async () => {
+    const sb = sandbox('opaque-file');
+    const f = path.join(sb.root, 'task.md');
+    const task = 'explain what git diff --check verifies, and what --json does';
+    fs.writeFileSync(f, `${task}\n`);
+    const r = run(sb, ['staffer', '--prompt-file', f]);
+    assert.equal(r.code, 0, r.stderr);
+    await waitForJob(sb, jobIdOf(r.stdout));
+    const [argv] = await waitForCalls(sb, 1);
+    assert.ok(promptOf(argv).includes(task));
+    assert.ok(!argv.includes('--json-schema'));
+  });
+
+  test('--stdin content containing companion flags is never scanned', async () => {
+    const sb = sandbox('opaque-stdin');
+    const task = 'a task piped via stdin that mentions --restricted and --timeout 1s';
+    const r = run(sb, ['staffer', '--stdin'], {}, { input: `${task}\n` });
+    assert.equal(r.code, 0, r.stderr);
+    assert.match(r.stdout, /profile: unrestricted/);
+    await waitForJob(sb, jobIdOf(r.stdout));
+    const [argv] = await waitForCalls(sb, 1);
+    assert.ok(promptOf(argv).includes(task));
+  });
+
+  test('real companion flags around --prompt still take effect', async () => {
+    const sb = sandbox('real-flags-around-prompt');
+    const task = 'Review this --json example and the --timeout 1s it mentions';
+    // --timeout 90s is deliberately NOT review's default (5m), so the
+    // assertion below proves the flag was honored rather than defaulted
+    const r = run(sb, ['review', '--restricted', '--prompt', task, '--json', '--timeout', '90s']);
+    assert.equal(r.code, 0, r.stderr);
+    assert.match(r.stdout, /profile: restricted/);
+    await waitForJob(sb, jobIdOf(r.stdout));
+    const [argv] = await waitForCalls(sb, 1);
+    assert.ok(argv.includes('--json-schema'), 'the real --json flag must enable the schema');
+    assert.equal(argv[argv.indexOf('--print-timeout') + 1], '90s');
+    assert.ok(promptOf(argv).includes(task));
+  });
+
+  test('a flag-shaped prompt with whitespace is a sentence, not a flag', async () => {
+    const sb = sandbox('prompt-leading-flag');
+    const task = '--check means what in git diff?';
+    const r = run(sb, ['ask', '--prompt', task]);
+    assert.equal(r.code, 0, r.stderr);
+    const [argv] = await waitForCalls(sb, 1);
+    assert.ok(promptOf(argv).includes(task), `prompt lost the task text: ${promptOf(argv)}`);
+  });
+
+  test('prompt bytes survive verbatim: quotes, newlines and double spaces', async () => {
+    const sb = sandbox('prompt-bytes');
+    const task = 'line one  with "double"  spaces\nline two with \'single\' quotes and --check\n\nline four';
+    const r = run(sb, ['ask', '--prompt', task]);
+    assert.equal(r.code, 0, r.stderr);
+    const [argv] = await waitForCalls(sb, 1);
+    const prompt = promptOf(argv);
+    assert.ok(prompt.includes(task), `bytes were altered:\n${JSON.stringify(prompt)}`);
+  });
+
+  test('continue reaches the state check with a flag-like follow-up', () => {
+    const sb = sandbox('continue-opaque');
+    const r = run(sb, ['continue', '--prompt', 'now check --check again']);
+    assert.notEqual(r.code, 0);
+    // the point: it fails on "no conversation yet", not on flag parsing
+    assert.match(r.stderr, /no previous agy-staff conversation recorded/);
+    assert.doesNotMatch(r.stderr, /unknown flag/);
+    assert.doesNotMatch(r.stderr, /needs a value/);
+  });
+});
+
+describe('task text comes only from the three sources', () => {
+  test('a positional word on a run command dies with the three sources named', () => {
+    const sb = sandbox('positional-word');
+    const r = run(sb, ['staffer', 'do the thing']);
+    assert.notEqual(r.code, 0);
+    assert.match(
+      r.stderr,
+      /positional task text was removed; pass the task with --prompt <text>, --prompt-file <path>, or --stdin/
+    );
+    assert.equal(agyCalls(sb).length, 0, 'agy must not be invoked');
+  });
+
+  test('an empty positional (an unset shell variable) dies loudly, never silently', () => {
+    const sb = sandbox('positional-empty');
+    // the shape produced by `ask --prompt "$Q" "$EXTRA"` with $EXTRA unset
+    const r = run(sb, ['ask', '--prompt', 'a question', '']);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /positional task text was removed/);
+    assert.equal(agyCalls(sb).length, 0, 'agy must not be invoked');
+  });
+
+  test('one big string of flags plus task points at the real fix', () => {
+    const sb = sandbox('packed-string');
+    const r = run(sb, ['review', '--restricted Review PR #730']);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /unknown flag --restricted/);
+    assert.match(r.stderr, /arrived as a single argument/);
+    assert.match(r.stderr, /never splits an argument into flags/);
+    assert.match(r.stderr, /--prompt/);
+    assert.equal(agyCalls(sb).length, 0, 'agy must not be invoked');
+  });
+
+  test('-- has no special meaning', () => {
+    const sb = sandbox('no-sentinel');
+    const r = run(sb, ['ask', '--', 'a question']);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /^agy-staff error: unknown flag --$/m);
+    assert.equal(agyCalls(sb).length, 0, 'agy must not be invoked');
+  });
+});
+
+describe('value flags need a real value', () => {
+  test('a forgotten --prompt value is caught instead of eating the next flag', () => {
+    const sb = sandbox('prompt-eats-flag');
+    const r = run(sb, ['ask', '--prompt', '--json']);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /flag --prompt needs a value/);
+    assert.match(r.stderr, /quote the full sentence or use --prompt-file/);
+    assert.equal(agyCalls(sb).length, 0, 'agy must not be invoked');
+  });
+
+  test('an empty --model value is an error, not a silent default', () => {
+    const sb = sandbox('empty-model');
+    const r = run(sb, ['ask', '--model', '', '--prompt', 'a question']);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /flag --model needs a value/);
+    assert.equal(agyCalls(sb).length, 0, 'agy must not be invoked');
+  });
+
+  test('a value flag at the end of argv is an error', () => {
+    const sb = sandbox('missing-value');
+    const r = run(sb, ['ask', '--prompt', 'a question', '--timeout']);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /flag --timeout needs a value/);
+  });
+
+  test('a flag-shaped value for a non-prompt flag is an error', () => {
+    const sb = sandbox('flag-shaped-value');
+    const r = run(sb, ['ask', '--model', '--effort', 'low', '--prompt', 'a question']);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /flag --model needs a value/);
+  });
+});
+
+describe('management commands are unaffected by the task-source change', () => {
+  test('wait <id> --timeout keeps parsing its positional id and its flag', async () => {
+    const sb = sandbox('mgmt-wait');
+    const started = run(sb, ['research', '--prompt', 'a topic'], { FAKE_AGY_SLEEP_MS: '3000' });
+    assert.equal(started.code, 0, started.stderr);
+    const id = jobIdOf(started.stdout);
+
+    const early = run(sb, ['wait', id, '--timeout', '1s']);
+    assert.equal(early.code, 2, `expected still-running, got ${early.code}: ${early.stderr}`);
+    assert.equal(await waitForJob(sb, id), 'done');
+
+    const status = run(sb, ['status']);
+    assert.equal(status.code, 0, status.stderr);
+    assert.match(status.stdout, new RegExp(id));
+  });
+
+  test('setup --restrict still takes its positional-free value', () => {
+    const sb = sandbox('mgmt-setup');
+    const r = run(sb, ['setup', '--restrict', 'review']);
+    assert.equal(r.code, 0, r.stderr);
+    const cfg = JSON.parse(
+      fs.readFileSync(path.join(sb.repo, '.agy-staff', 'config.json'), 'utf8')
+    );
+    assert.equal(cfg.profiles.review, 'restricted');
+  });
+
+  test('removed migration flags still die with their own message', () => {
+    const sb = sandbox('mgmt-migration');
+    const r = run(sb, ['review', '--pr', '730']);
+    assert.notEqual(r.code, 0);
+    assert.match(r.stderr, /--pr was removed in 0\.2: review is prompt-based now\./);
+    assert.match(r.stderr, /review --prompt "Review PR #730"/);
   });
 });
 
@@ -80,7 +306,7 @@ describe('.agy-staff/ hygiene is automatic', () => {
     const exclude = path.join(sb.repo, '.git', 'info', 'exclude');
     fs.writeFileSync(exclude, '');
 
-    const r = run(sb, ['ask', 'a question']);
+    const r = run(sb, ['ask', '--prompt', 'a question']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(fs.readFileSync(exclude, 'utf8'), /^\.agy-staff\/$/m);
     const check = spawnSync('git', ['check-ignore', '-q', '.agy-staff'], { cwd: sb.repo });
@@ -92,7 +318,7 @@ describe('.agy-staff/ hygiene is automatic', () => {
     const exclude = path.join(sb.repo, '.git', 'info', 'exclude');
     const before = fs.readFileSync(exclude, 'utf8');
 
-    const r = run(sb, ['ask', 'a question']);
+    const r = run(sb, ['ask', '--prompt', 'a question']);
     assert.equal(r.code, 0, r.stderr);
     assert.equal(fs.readFileSync(exclude, 'utf8'), before);
   });

--- a/tests/flags.test.mjs
+++ b/tests/flags.test.mjs
@@ -8,9 +8,9 @@ import { sandbox, run, agyCalls } from './helpers.mjs';
 
 describe('removed review flags (--diff-file / --pr / --target)', () => {
   for (const [flag, args] of [
-    ['--diff-file', ['review', '--diff-file', '/tmp/x.patch', 'subject']],
-    ['--pr', ['review', '--pr', '730', 'subject']],
-    ['--target', ['review', '--target', 'master', 'subject']],
+    ['--diff-file', ['review', '--diff-file', '/tmp/x.patch', '--prompt', 'subject']],
+    ['--pr', ['review', '--pr', '730', '--prompt', 'subject']],
+    ['--target', ['review', '--target', 'master', '--prompt', 'subject']],
   ]) {
     test(`${flag} dies with the prompt-based migration message`, () => {
       const sb = sandbox('removed-review');
@@ -21,8 +21,8 @@ describe('removed review flags (--diff-file / --pr / --target)', () => {
         new RegExp(`${flag} was removed in 0\\.2: review is prompt-based now\\.`)
       );
       assert.match(r.stderr, /Describe the subject in the prompt/);
-      assert.match(r.stderr, /review "Review PR #730"/);
-      assert.match(r.stderr, /review "Review changes against master"/);
+      assert.match(r.stderr, /review --prompt "Review PR #730"/);
+      assert.match(r.stderr, /review --prompt "Review changes against master"/);
       // no execution-style advice leaking into the review message
       assert.doesNotMatch(r.stderr, /execution style is fixed per mode/);
       assert.equal(agyCalls(sb).length, 0, 'agy must not be invoked');
@@ -32,10 +32,10 @@ describe('removed review flags (--diff-file / --pr / --target)', () => {
 
 describe('removed execution flags (--background / --wait)', () => {
   for (const [flag, args] of [
-    ['--background', ['research', '--background', 'task']],
-    ['--wait', ['research', '--wait', 'task']],
+    ['--background', ['research', '--background', '--prompt', 'task']],
+    ['--wait', ['research', '--wait', '--prompt', 'task']],
     // also removed for ask, whose 0.1 special case is now moot
-    ['--background', ['ask', '--background', 'question']],
+    ['--background', ['ask', '--background', '--prompt', 'question']],
   ]) {
     test(`${flag} dies with the fixed-execution-style migration message`, () => {
       const sb = sandbox('removed-exec');
@@ -59,7 +59,7 @@ describe('removed execution flags (--background / --wait)', () => {
 describe('deprecated aliases', () => {
   test('--strict maps to restricted and warns once on stderr', () => {
     const sb = sandbox('alias-strict');
-    const r = run(sb, ['implement', '--strict', 'do a thing']);
+    const r = run(sb, ['implement', '--strict', '--prompt', 'do a thing']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stderr, /^agy-staff: --strict is deprecated; use --restricted$/m);
     // implement defaults to unrestricted, so the alias is what flips it
@@ -68,7 +68,7 @@ describe('deprecated aliases', () => {
 
   test('--loose maps to unrestricted and warns once on stderr', () => {
     const sb = sandbox('alias-loose');
-    const r = run(sb, ['research', '--loose', 'a topic']);
+    const r = run(sb, ['research', '--loose', '--prompt', 'a topic']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stderr, /^agy-staff: --loose is deprecated; use --unrestricted$/m);
     // research is unrestricted by default in 0.2 round 2, so --loose is now
@@ -78,7 +78,7 @@ describe('deprecated aliases', () => {
 
   test('--restricted with the --loose alias is mutually exclusive', () => {
     const sb = sandbox('alias-conflict');
-    const r = run(sb, ['research', '--restricted', '--loose', 'a topic']);
+    const r = run(sb, ['research', '--restricted', '--loose', '--prompt', 'a topic']);
     assert.notEqual(r.code, 0);
     assert.match(r.stderr, /--restricted and --unrestricted are mutually exclusive/);
     assert.equal(agyCalls(sb).length, 0, 'agy must not be invoked');
@@ -86,7 +86,7 @@ describe('deprecated aliases', () => {
 
   test('--restricted with --unrestricted is mutually exclusive', () => {
     const sb = sandbox('conflict');
-    const r = run(sb, ['research', '--restricted', '--unrestricted', 'a topic']);
+    const r = run(sb, ['research', '--restricted', '--unrestricted', '--prompt', 'a topic']);
     assert.notEqual(r.code, 0);
     assert.match(r.stderr, /--restricted and --unrestricted are mutually exclusive/);
   });

--- a/tests/jobs.test.mjs
+++ b/tests/jobs.test.mjs
@@ -18,7 +18,7 @@ import {
 describe('background job lifecycle', () => {
   test('status → result → cancel over one finished job', async () => {
     const sb = sandbox('lifecycle');
-    const started = run(sb, ['research', 'a topic']);
+    const started = run(sb, ['research', '--prompt', 'a topic']);
     assert.equal(started.code, 0, started.stderr);
     const id = jobIdOf(started.stdout);
 
@@ -69,10 +69,10 @@ describe('background job lifecycle', () => {
 describe('continue inherits the resumed mode default', () => {
   test('after ask, continue runs in the foreground', () => {
     const sb = sandbox('continue-ask');
-    const first = run(sb, ['ask', 'what is 2 plus 2?']);
+    const first = run(sb, ['ask', '--prompt', 'what is 2 plus 2?']);
     assert.equal(first.code, 0, first.stderr);
 
-    const cont = run(sb, ['continue', 'and what about 3 plus 3?']);
+    const cont = run(sb, ['continue', '--prompt', 'and what about 3 plus 3?']);
     assert.equal(cont.code, 0, cont.stderr);
     assert.match(cont.stdout, /fake answer/);
     assert.doesNotMatch(cont.stdout, /\[agy-staff\]/);
@@ -90,11 +90,11 @@ describe('continue inherits the resumed mode default', () => {
 
   test('after research, continue starts a background job', async () => {
     const sb = sandbox('continue-research');
-    const first = run(sb, ['research', 'a topic']);
+    const first = run(sb, ['research', '--prompt', 'a topic']);
     assert.equal(first.code, 0, first.stderr);
     await waitForJob(sb, jobIdOf(first.stdout));
 
-    const cont = run(sb, ['continue', 'dig into the second part']);
+    const cont = run(sb, ['continue', '--prompt', 'dig into the second part']);
     assert.equal(cont.code, 0, cont.stderr);
     assert.match(cont.stdout, /Started background research job\./);
     const secondId = jobIdOf(cont.stdout);
@@ -107,7 +107,7 @@ describe('continue inherits the resumed mode default', () => {
 
   test('continue with no follow-up text and no history fails', () => {
     const sb = sandbox('continue-empty');
-    const none = run(sb, ['continue', 'text with no history']);
+    const none = run(sb, ['continue', '--prompt', 'text with no history']);
     assert.notEqual(none.code, 0);
     assert.match(none.stderr, /no previous agy-staff conversation recorded/);
   });

--- a/tests/modes.test.mjs
+++ b/tests/modes.test.mjs
@@ -33,7 +33,7 @@ const SKIP = '--dangerously-skip-permissions';
 describe('execution style is fixed per mode', () => {
   test('ask runs in the foreground and returns the answer synchronously', () => {
     const sb = sandbox('ask');
-    const r = run(sb, ['ask', 'what is 2 plus 2?']);
+    const r = run(sb, ['ask', '--prompt', 'what is 2 plus 2?']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stdout, /fake answer/);
     assert.doesNotMatch(r.stdout, /Started background/);
@@ -42,7 +42,7 @@ describe('execution style is fixed per mode', () => {
 
   test('ask keeps the answer on stdout and the telemetry on stderr', () => {
     const sb = sandbox('ask-telemetry');
-    const r = run(sb, ['ask', 'what is 2 plus 2?']);
+    const r = run(sb, ['ask', '--prompt', 'what is 2 plus 2?']);
     assert.equal(r.code, 0, r.stderr);
 
     // stdout is the deliverable only — no plumbing for the user to read
@@ -65,7 +65,7 @@ describe('execution style is fixed per mode', () => {
   ]) {
     test(`${mode} starts a background job immediately`, () => {
       const sb = sandbox(`bg-${mode}`);
-      const r = run(sb, [mode, task]);
+      const r = run(sb, [mode, '--prompt', task]);
       assert.equal(r.code, 0, r.stderr);
       assert.match(r.stdout, new RegExp(`Started background ${mode} job\\.`));
       const id = jobIdOf(r.stdout);
@@ -93,7 +93,7 @@ describe('permission profile wiring reaches the agy argv', () => {
   ]) {
     test(`${mode} defaults to unrestricted → passes --dangerously-skip-permissions`, async () => {
       const sb = sandbox(`prof-${mode}`);
-      const r = run(sb, [mode, task]);
+      const r = run(sb, [mode, '--prompt', task]);
       assert.equal(r.code, 0, r.stderr);
       assert.match(r.stdout, /profile: unrestricted/);
       assert.doesNotMatch(r.stdout, /profile: restricted/);
@@ -104,7 +104,7 @@ describe('permission profile wiring reaches the agy argv', () => {
 
     test(`${mode} --restricted opts out → no --dangerously-skip-permissions`, async () => {
       const sb = sandbox(`prof-${mode}-restricted`);
-      const r = run(sb, [mode, '--restricted', task]);
+      const r = run(sb, [mode, '--restricted', '--prompt', task]);
       assert.equal(r.code, 0, r.stderr);
       assert.match(r.stdout, /profile: restricted/);
       await waitForJob(sb, jobIdOf(r.stdout));
@@ -115,7 +115,7 @@ describe('permission profile wiring reaches the agy argv', () => {
 
   test('research --unrestricted is redundant but still explicit', async () => {
     const sb = sandbox('prof-research-un');
-    const r = run(sb, ['research', '--unrestricted', 'a topic']);
+    const r = run(sb, ['research', '--unrestricted', '--prompt', 'a topic']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stdout, /profile: unrestricted/);
     await waitForJob(sb, jobIdOf(r.stdout));
@@ -125,7 +125,7 @@ describe('permission profile wiring reaches the agy argv', () => {
 
   test('ask never gets --dangerously-skip-permissions', () => {
     const sb = sandbox('prof-ask');
-    const r = run(sb, ['ask', 'what is 2 plus 2?']);
+    const r = run(sb, ['ask', '--prompt', 'what is 2 plus 2?']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stderr, /profile=restricted/);
     const [argv] = agyCalls(sb);
@@ -134,7 +134,7 @@ describe('permission profile wiring reaches the agy argv', () => {
 
   test('ask --unrestricted is ignored: note on stderr, still restricted', () => {
     const sb = sandbox('prof-ask-un');
-    const r = run(sb, ['ask', '--unrestricted', 'what is 2 plus 2?']);
+    const r = run(sb, ['ask', '--unrestricted', '--prompt', 'what is 2 plus 2?']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stderr, /^agy-staff: ask is tool-free; --unrestricted ignored$/m);
     assert.match(r.stderr, /profile=restricted/);
@@ -145,7 +145,7 @@ describe('permission profile wiring reaches the agy argv', () => {
 
   test('a --restricted run coming back empty gets the reworded triage message', async () => {
     const sb = sandbox('restricted-empty');
-    const started = run(sb, ['research', '--restricted', 'a topic'], {
+    const started = run(sb, ['research', '--restricted', '--prompt', 'a topic'], {
       FAKE_AGY_RESPONSE: '',
     });
     assert.equal(started.code, 0, started.stderr);
@@ -167,7 +167,7 @@ describe('permission profile wiring reaches the agy argv', () => {
 
   test('an unrestricted empty response never suggests setup or --restricted', async () => {
     const sb = sandbox('unrestricted-empty');
-    const started = run(sb, ['research', 'a topic'], { FAKE_AGY_RESPONSE: '' });
+    const started = run(sb, ['research', '--prompt', 'a topic'], { FAKE_AGY_RESPONSE: '' });
     assert.equal(started.code, 0, started.stderr);
     const id = jobIdOf(started.stdout);
     assert.equal(await waitForJob(sb, id), 'error');
@@ -180,7 +180,7 @@ describe('permission profile wiring reaches the agy argv', () => {
 
   test('EPERM in agy stderr gets the harness-sandbox hint', async () => {
     const sb = sandbox('sandbox-eperm');
-    const started = run(sb, ['research', 'a topic'], {
+    const started = run(sb, ['research', '--prompt', 'a topic'], {
       FAKE_AGY_NO_JSON: '1',
       FAKE_AGY_STDERR:
         'ERROR: creating log file: opening /home/u/.gemini/antigravity-cli/log/cli.log: operation not permitted',
@@ -197,7 +197,7 @@ describe('permission profile wiring reaches the agy argv', () => {
 
   test('a non-JSON crash without EPERM gets no sandbox hint', async () => {
     const sb = sandbox('crash-no-hint');
-    const started = run(sb, ['research', 'a topic'], {
+    const started = run(sb, ['research', '--prompt', 'a topic'], {
       FAKE_AGY_NO_JSON: '1',
       FAKE_AGY_STDERR: 'segfault somewhere unrelated',
     });
@@ -214,7 +214,7 @@ describe('permission profile wiring reaches the agy argv', () => {
 describe('tiered git guards: implement', () => {
   test('implement defaults to high effort Flash', async () => {
     const sb = sandbox('impl-default-model');
-    const started = run(sb, ['implement', 'a task']);
+    const started = run(sb, ['implement', '--prompt', 'a task']);
     assert.equal(started.code, 0, started.stderr);
     assert.match(started.stdout, /model: gemini-3\.7-flash-high/);
 
@@ -228,7 +228,7 @@ describe('tiered git guards: implement', () => {
     const sb = sandbox('dirty');
     fs.writeFileSync(path.join(sb.repo, 'dirty.txt'), 'uncommitted\n');
 
-    const r = run(sb, ['implement', 'a task']);
+    const r = run(sb, ['implement', '--prompt', 'a task']);
     assert.equal(r.code, 0, r.stderr);
     assert.doesNotMatch(r.stderr, /unrestricted profile refused/);
     assert.match(r.stdout, /Started background implement job\./);
@@ -248,7 +248,7 @@ describe('tiered git guards: implement', () => {
       fs.writeFileSync(path.join(sb.repo, `dirty-${String(i).padStart(3, '0')}.txt`), 'x\n');
     }
 
-    const r = run(sb, ['implement', 'a task']);
+    const r = run(sb, ['implement', '--prompt', 'a task']);
     assert.equal(r.code, 0, r.stderr);
     const id = jobIdOf(r.stdout);
     assert.equal(await waitForJob(sb, id), 'done');
@@ -265,7 +265,7 @@ describe('tiered git guards: implement', () => {
 
   test('implement outside a git repository warns and proceeds', async () => {
     const sb = sandbox('no-git', { git: false });
-    const r = run(sb, ['implement', 'a task']);
+    const r = run(sb, ['implement', '--prompt', 'a task']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stderr, /not a git repository/);
     assert.match(r.stderr, /cannot be reviewed or rolled back via git/);
@@ -290,7 +290,7 @@ describe('tiered git guards: implement', () => {
 
   test('implement reports the tree with the [unrestricted] prefix', async () => {
     const sb = sandbox('guard-report');
-    const started = run(sb, ['implement', 'a task']);
+    const started = run(sb, ['implement', '--prompt', 'a task']);
     assert.equal(started.code, 0, started.stderr);
     const id = jobIdOf(started.stdout);
     assert.equal(await waitForJob(sb, id), 'done');
@@ -309,7 +309,7 @@ describe('tiered git guards: implement', () => {
 
   test('implement reports edits agy made on the clean tree', async () => {
     const sb = sandbox('impl-touched');
-    const started = run(sb, ['implement', 'a task'], {
+    const started = run(sb, ['implement', '--prompt', 'a task'], {
       FAKE_AGY_TOUCH_FILE: path.join(sb.repo, 'agy-wrote.txt'),
     });
     assert.equal(started.code, 0, started.stderr);
@@ -324,13 +324,13 @@ describe('tiered git guards: implement', () => {
 
   test('implement continuation can build on its own dirty result', async () => {
     const sb = sandbox('impl-continue-dirty');
-    const first = run(sb, ['implement', 'write a file'], {
+    const first = run(sb, ['implement', '--prompt', 'write a file'], {
       FAKE_AGY_TOUCH_FILE: path.join(sb.repo, 'agy-wrote.txt'),
     });
     assert.equal(first.code, 0, first.stderr);
     assert.equal(await waitForJob(sb, jobIdOf(first.stdout)), 'done');
 
-    const cont = run(sb, ['continue', 'refine the same change']);
+    const cont = run(sb, ['continue', '--prompt', 'refine the same change']);
     assert.equal(cont.code, 0, cont.stderr);
     assert.match(cont.stdout, /Started background implement job\./);
     assert.equal(await waitForJob(sb, jobIdOf(cont.stdout)), 'done');
@@ -352,7 +352,7 @@ describe('tiered git guards: review / research are never blocked', () => {
       const sb = sandbox(`dirty-${mode}`);
       fs.writeFileSync(path.join(sb.repo, 'dirty.txt'), 'uncommitted\n');
 
-      const r = run(sb, [mode, task]);
+      const r = run(sb, [mode, '--prompt', task]);
       assert.equal(r.code, 0, r.stderr);
       assert.doesNotMatch(r.stderr, /working tree is not clean/);
       assert.match(r.stdout, new RegExp(`Started background ${mode} job\\.`));
@@ -368,7 +368,7 @@ describe('tiered git guards: review / research are never blocked', () => {
 
   test('review outside a git repository runs with no tree report', async () => {
     const sb = sandbox('review-no-git', { git: false });
-    const r = run(sb, ['review', 'Review the working tree']);
+    const r = run(sb, ['review', '--prompt', 'Review the working tree']);
     assert.equal(r.code, 0, r.stderr);
     const id = jobIdOf(r.stdout);
     assert.equal(await waitForJob(sb, id), 'done');
@@ -383,7 +383,7 @@ describe('tiered git guards: review / research are never blocked', () => {
 describe('working-tree delta report (review / research)', () => {
   test('review reports the file agy touched during the run', async () => {
     const sb = sandbox('delta-review');
-    const r = run(sb, ['review', 'Review PR #730'], {
+    const r = run(sb, ['review', '--prompt', 'Review PR #730'], {
       FAKE_AGY_TOUCH_FILE: path.join(sb.repo, 'sneaky.txt'),
     });
     assert.equal(r.code, 0, r.stderr);
@@ -410,7 +410,7 @@ describe('working-tree delta report (review / research)', () => {
 
   test('the delta report is silent when agy touched nothing', async () => {
     const sb = sandbox('delta-review-clean');
-    const r = run(sb, ['review', 'Review PR #730']);
+    const r = run(sb, ['review', '--prompt', 'Review PR #730']);
     assert.equal(r.code, 0, r.stderr);
     const id = jobIdOf(r.stdout);
     assert.equal(await waitForJob(sb, id), 'done');
@@ -427,7 +427,7 @@ describe('working-tree delta report (review / research)', () => {
     const sb = sandbox('delta-review-dirty');
     fs.writeFileSync(path.join(sb.repo, 'pre-existing.txt'), 'was here first\n');
 
-    const r = run(sb, ['review', 'Review the working tree'], {
+    const r = run(sb, ['review', '--prompt', 'Review the working tree'], {
       FAKE_AGY_TOUCH_FILE: path.join(sb.repo, 'sneaky.txt'),
     });
     assert.equal(r.code, 0, r.stderr);
@@ -442,7 +442,7 @@ describe('working-tree delta report (review / research)', () => {
 
   test('research reports the delta too', async () => {
     const sb = sandbox('delta-research');
-    const r = run(sb, ['research', 'a topic'], {
+    const r = run(sb, ['research', '--prompt', 'a topic'], {
       FAKE_AGY_TOUCH_FILE: path.join(sb.repo, 'notes.txt'),
     });
     assert.equal(r.code, 0, r.stderr);
@@ -459,7 +459,7 @@ describe('working-tree delta report (review / research)', () => {
 
   test('a --restricted review reports no delta (guards are unrestricted-only)', async () => {
     const sb = sandbox('delta-restricted');
-    const r = run(sb, ['review', '--restricted', 'Review PR #730'], {
+    const r = run(sb, ['review', '--restricted', '--prompt', 'Review PR #730'], {
       FAKE_AGY_TOUCH_FILE: path.join(sb.repo, 'sneaky.txt'),
     });
     assert.equal(r.code, 0, r.stderr);
@@ -477,7 +477,7 @@ describe('working-tree delta report (review / research)', () => {
 describe('kept and rejected flags', () => {
   test('review --json passes a schema to agy', async () => {
     const sb = sandbox('review-json');
-    const r = run(sb, ['review', '--json', 'Review PR #730']);
+    const r = run(sb, ['review', '--json', '--prompt', 'Review PR #730']);
     assert.equal(r.code, 0, r.stderr);
     await waitForJob(sb, jobIdOf(r.stdout));
     const [argv] = await waitForCalls(sb, 1);
@@ -488,7 +488,7 @@ describe('kept and rejected flags', () => {
 
   test('an undocumented flag is rejected as unknown', () => {
     const sb = sandbox('unknown-flag');
-    const r = run(sb, ['research', '--nope', 'a topic']);
+    const r = run(sb, ['research', '--nope', '--prompt', 'a topic']);
     assert.notEqual(r.code, 0);
     assert.match(r.stderr, /unknown flag --nope/);
   });
@@ -501,14 +501,14 @@ describe('review is prompt-based', () => {
     assert.notEqual(r.code, 0);
     assert.match(
       r.stderr,
-      /review needs a subject description, e\.g\. review "Review PR #730" or review "Review the current working tree"/
+      /review needs a subject description, e\.g\. review --prompt "Review PR #730" or review --prompt "Review the current working tree"/
     );
     assert.equal(agyCalls(sb).length, 0);
   });
 
-  test('review "Review PR #730" works with no flags and puts the task in the prompt', async () => {
+  test('review --prompt "Review PR #730" works with no other flags and puts the task in the prompt', async () => {
     const sb = sandbox('review-pr');
-    const r = run(sb, ['review', 'Review PR #730']);
+    const r = run(sb, ['review', '--prompt', 'Review PR #730']);
     assert.equal(r.code, 0, r.stderr);
     await waitForJob(sb, jobIdOf(r.stdout));
     const [argv] = await waitForCalls(sb, 1);

--- a/tests/policy.test.mjs
+++ b/tests/policy.test.mjs
@@ -76,7 +76,7 @@ describe('profile precedence: flag > project policy > default', () => {
   test('a policy-restricted mode runs without --dangerously-skip-permissions', async () => {
     const sb = sandbox('policy-applies');
     run(sb, ['setup', '--restrict', 'review']);
-    const r = run(sb, ['review', 'Review the current working tree']);
+    const r = run(sb, ['review', '--prompt', 'Review the current working tree']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stdout, /profile: restricted/);
     assert.match(r.stderr, /profile=restricted set by project policy/);
@@ -90,7 +90,7 @@ describe('profile precedence: flag > project policy > default', () => {
   test('unlisted modes keep the built-in default', async () => {
     const sb = sandbox('policy-unlisted');
     run(sb, ['setup', '--restrict', 'review']);
-    const r = run(sb, ['research', 'a topic']);
+    const r = run(sb, ['research', '--prompt', 'a topic']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stdout, /profile: unrestricted/);
     const calls = await waitForCalls(sb, 1);
@@ -100,7 +100,7 @@ describe('profile precedence: flag > project policy > default', () => {
   test('an explicit flag overrides the policy', async () => {
     const sb = sandbox('policy-flag-wins');
     run(sb, ['setup', '--restrict', 'review']);
-    const r = run(sb, ['review', '--unrestricted', 'Review the current working tree']);
+    const r = run(sb, ['review', '--unrestricted', '--prompt', 'Review the current working tree']);
     assert.equal(r.code, 0, r.stderr);
     assert.match(r.stdout, /profile: unrestricted/);
     assert.doesNotMatch(r.stderr, /set by project policy/);
@@ -120,7 +120,7 @@ describe('profile precedence: flag > project policy > default', () => {
     const sb = sandbox('policy-corrupt');
     fs.mkdirSync(path.join(sb.repo, '.agy-staff'), { recursive: true });
     fs.writeFileSync(configFile(sb), '{nope');
-    const r = run(sb, ['review', 'Review the tree']);
+    const r = run(sb, ['review', '--prompt', 'Review the tree']);
     assert.notEqual(r.code, 0);
     assert.match(r.stderr, /project config is corrupt/);
   });

--- a/tests/state.test.mjs
+++ b/tests/state.test.mjs
@@ -29,7 +29,7 @@ test('background job survives an instant worker (registered before spawn)', asyn
   const sb = sandbox('instant-worker');
   // No latency floor: with post-spawn registration this made the job record
   // vanish from state.json (~30% of runs); pre-spawn registration must hold.
-  const r = run(sb, ['research', 'quick task'], { FAKE_AGY_SLEEP_MS: '0' });
+  const r = run(sb, ['research', '--prompt', 'quick task'], { FAKE_AGY_SLEEP_MS: '0' });
   assert.equal(r.code, 0);
   const id = jobIdOf(r.stdout);
   const status = await waitForJob(sb, id);

--- a/tests/triage.test.mjs
+++ b/tests/triage.test.mjs
@@ -15,7 +15,7 @@ import { sandbox, run, jobIdOf, jobLog, waitForJob } from './helpers.mjs';
 describe('done_with_warnings: non-SUCCESS status with a complete response', () => {
   test('foreground (ask): exit 0, response intact on stdout, warning on stderr', () => {
     const sb = sandbox('triage-warn-fg');
-    const r = run(sb, ['ask', 'a question'], {
+    const r = run(sb, ['ask', '--prompt', 'a question'], {
       FAKE_AGY_STATUS: 'ERROR',
       FAKE_AGY_RESPONSE: 'the full answer, produced before the failure',
     });
@@ -27,7 +27,7 @@ describe('done_with_warnings: non-SUCCESS status with a complete response', () =
 
   test('background (research): job ends done, wait exits 0 and prints the response', async () => {
     const sb = sandbox('triage-warn-bg');
-    const started = run(sb, ['research', 'a topic'], {
+    const started = run(sb, ['research', '--prompt', 'a topic'], {
       FAKE_AGY_STATUS: 'ERROR',
       FAKE_AGY_RESPONSE: 'survey results',
     });
@@ -44,7 +44,7 @@ describe('done_with_warnings: non-SUCCESS status with a complete response', () =
 describe('cause hints are conditional on the error text', () => {
   test('an unrelated error (tool timeout) gets no model/auth/quota hint', () => {
     const sb = sandbox('triage-hint-none');
-    const r = run(sb, ['ask', 'a question'], {
+    const r = run(sb, ['ask', '--prompt', 'a question'], {
       FAKE_AGY_STATUS: 'ERROR',
       FAKE_AGY_RESPONSE: '',
       FAKE_AGY_STDERR: 'grep: process timed out after 30s',
@@ -56,7 +56,7 @@ describe('cause hints are conditional on the error text', () => {
 
   test('a model-id error gets exactly the model hint', () => {
     const sb = sandbox('triage-hint-model');
-    const r = run(sb, ['ask', 'a question'], {
+    const r = run(sb, ['ask', '--prompt', 'a question'], {
       FAKE_AGY_STATUS: 'ERROR',
       FAKE_AGY_RESPONSE: '',
       FAKE_AGY_ERROR: '--model gemini-3.7-flash requires --effort',

--- a/tests/wait.test.mjs
+++ b/tests/wait.test.mjs
@@ -14,7 +14,7 @@ import { sandbox, run, jobIdOf, jobLog, waitForJob } from './helpers.mjs';
 describe('status <id> exit codes', () => {
   test('running → 2, done → 0', async () => {
     const sb = sandbox('waitc-status');
-    const started = run(sb, ['research', 'a topic'], { FAKE_AGY_SLEEP_MS: '3000' });
+    const started = run(sb, ['research', '--prompt', 'a topic'], { FAKE_AGY_SLEEP_MS: '3000' });
     const id = jobIdOf(started.stdout);
 
     const running = run(sb, ['status', id]);
@@ -30,7 +30,7 @@ describe('status <id> exit codes', () => {
     const sb = sandbox('waitc-status-err');
     // an ERROR with a response would be delivered (done_with_warnings); a real
     // failure has no response
-    const started = run(sb, ['research', 'a topic'], { FAKE_AGY_STATUS: 'ERROR', FAKE_AGY_RESPONSE: '' });
+    const started = run(sb, ['research', '--prompt', 'a topic'], { FAKE_AGY_STATUS: 'ERROR', FAKE_AGY_RESPONSE: '' });
     const id = jobIdOf(started.stdout);
     await waitForJob(sb, id);
 
@@ -43,7 +43,7 @@ describe('status <id> exit codes', () => {
 describe('wait', () => {
   test('blocks until done, prints the result, exits 0', async () => {
     const sb = sandbox('wait-done');
-    const started = run(sb, ['research', 'a topic']);
+    const started = run(sb, ['research', '--prompt', 'a topic']);
     const id = jobIdOf(started.stdout);
 
     const r = run(sb, ['wait', id]);
@@ -54,7 +54,7 @@ describe('wait', () => {
 
   test('the delivered result is the body only; telemetry stays in the job log', async () => {
     const sb = sandbox('wait-telemetry');
-    const started = run(sb, ['research', 'a topic']);
+    const started = run(sb, ['research', '--prompt', 'a topic']);
     const id = jobIdOf(started.stdout);
 
     const r = run(sb, ['wait', id]);
@@ -70,7 +70,7 @@ describe('wait', () => {
 
   test('own timeout while the job runs → exit 2, then a second wait succeeds', async () => {
     const sb = sandbox('wait-timeout');
-    const started = run(sb, ['research', 'a topic'], { FAKE_AGY_SLEEP_MS: '5000' });
+    const started = run(sb, ['research', '--prompt', 'a topic'], { FAKE_AGY_SLEEP_MS: '5000' });
     const id = jobIdOf(started.stdout);
 
     const first = run(sb, ['wait', id, '--timeout', '1s']);
@@ -85,7 +85,7 @@ describe('wait', () => {
 
   test('failed job → exit 3 with the stored error', async () => {
     const sb = sandbox('wait-error');
-    const started = run(sb, ['research', 'a topic'], { FAKE_AGY_STATUS: 'ERROR', FAKE_AGY_RESPONSE: '' });
+    const started = run(sb, ['research', '--prompt', 'a topic'], { FAKE_AGY_STATUS: 'ERROR', FAKE_AGY_RESPONSE: '' });
     const id = jobIdOf(started.stdout);
 
     const r = run(sb, ['wait', id]);
@@ -95,7 +95,7 @@ describe('wait', () => {
 
   test('canceled job → exit 4', async () => {
     const sb = sandbox('wait-cancel');
-    const started = run(sb, ['research', 'a topic'], { FAKE_AGY_SLEEP_MS: '8000' });
+    const started = run(sb, ['research', '--prompt', 'a topic'], { FAKE_AGY_SLEEP_MS: '8000' });
     const id = jobIdOf(started.stdout);
     run(sb, ['cancel', id]);
 
@@ -107,7 +107,7 @@ describe('wait', () => {
     const sb = sandbox('wait-default');
     assert.equal(run(sb, ['wait', 'no-such-job']).code, 1);
 
-    const started = run(sb, ['research', 'a topic']);
+    const started = run(sb, ['research', '--prompt', 'a topic']);
     const id = jobIdOf(started.stdout);
     const r = run(sb, ['wait']);
     assert.equal(r.code, 0, r.stderr);


### PR DESCRIPTION
## What

Task text for the run commands (`staffer`, `research`, `review`, `implement`, `ask`, `continue`) now comes from exactly one of `--prompt <text>`, `--prompt-file <path>`, or `--stdin`. Positional task text is gone.

**This is a companion-CLI change only.** How you invoke a persona is unchanged: you still type your task as plain text after the slash command (`/agy:reviewer Review PR #730`), and the skill composes the `--prompt` call for you. You never type `--prompt` yourself.

## Why

`tokenize()` re-split any argv entry containing whitespace, and `parseFlags` then scanned every resulting token. The shell had already produced argv; splitting it a second time meant a prompt that mentioned `git diff --check` died with `agy-staff error: unknown flag --check`. The fix is not a smarter boundary rule — it is to stop tokenizing. The parser now reads the shell's real argv once, and a task value is never re-split, never quote-interpreted, and never inspected byte by byte.

## Design

1. **`tokenize()` is deleted.** argv is parsed exactly as the shell delivered it.
2. **Three task sources, exactly one per call**: `--prompt`, `--prompt-file`, `--stdin`. Two at once keeps the existing `task text given more than one way (…) — use exactly one` error, with those source labels.
3. **Positional task text is removed, not deprecated.** Any positional on a run command — including the empty string that `--prompt "$Q" "$EXTRA"` produces when `$EXTRA` is unset — dies with `positional task text was removed; pass the task with --prompt <text>, --prompt-file <path>, or --stdin`. No warning path, no compat path.
4. **No `--` sentinel.** `--` falls through to the normal unknown-flag error, same as on master.
5. **Value-flag hygiene** (`--conversation`, `--model`, `--effort`, `--timeout`, `--restrict`, `--prompt`, `--prompt-file`): a missing value, an empty value, or a flag-shaped value is an error. That kills the silent `--model ""` fallback and catches `ask --prompt --json`. The one exception is `--prompt` with a value that contains whitespace — a real sentence like `--prompt "--check 是干嘛的"` is accepted, because prompt bytes are never second-guessed.
6. **A flag name that still contains whitespace** (`review "--restricted Review PR #730"`) gets an error saying the companion never splits an argument into flags, and naming the fix.
7. **Management commands are untouched.** One shared `parseFlags` takes a `taskCommand` option that only changes what a positional means; `status`, `wait`, `result`, `cancel`, and `setup` keep collecting positionals as ids and values, so `wait <id> --timeout 30s` is unaffected.
8. `--prompt-file` / `--stdin` contents stay completely unscanned (already true, kept).

Removed/deprecated flags (`--pr`, `--diff-file`, `--target`, the exec set) keep their migration errors; only the example strings inside them move to the `--prompt` form. Implementer dirty-workspace policy, continuation state, delivery modes, and Git/PR orchestration are untouched (#1 territory).

## Breaking change

Positional task text and one-big-string flag parsing are removed at the CLI layer. Anything driving `node companion/agy-companion.mjs` directly moves from `ask "question"` to `ask --prompt "question"`, and from `review "--restricted Review PR #730"` to `review --restricted --prompt "Review PR #730"`. Both failure modes are loud and name the replacement.

## Release

Targets **0.4.5**. v0.4.4 is released and tagged, so `docs/releases/v0.4.4.md` is left exactly as it shipped; the new draft is `docs/releases/v0.4.5.md`.

Both plugin manifests are bumped to `0.4.5` in this commit, following the repo's convention rather than deferring to a separate `chore(release)`. Evidence: `027ed6c` (`feat(implementer): …`, the commit `v0.4.4` points at) bumped `.claude-plugin/plugin.json` and `.codex-plugin/plugin.json` from 0.4.3 to 0.4.4 **and** created `docs/releases/v0.4.4.md` in the same feature commit, while `5a5700d` (`chore(release): 0.4.3`) touched only the release note and no manifest. `git log -S'"version": "0.4.4"'` confirms `027ed6c` is the sole bump commit. No README badges or marketplace manifests carry a version.

## User layer vs CLI layer

An earlier revision of this PR wrongly put `--prompt` on slash-command examples. Corrected — every changed line is now classified by who executes it:

**User→agent layer (no `--prompt`, reverted to master):**
- `README.md:53` and `README.zh-CN.md:53` — `/agy:ask "reply with OK"` first-run smoke. Both files are now byte-identical to master and no longer appear in the diff.
- `docs/INSTALL_FOR_AGENTS.md:66` — `- Claude Code: /agy:ask "reply with OK"`. The adjacent line is `- Codex: $agy:ask reply with OK`, which settles it.
- All five `argument-hint:` frontmatter lines — restored to master byte for byte, trailing `"question"` / `"task"` / `"what to research"` / `"what to review"` / `"task description"` included, since argument-hint describes what the user types after the slash command.
- README's "what to type" table was never touched.

**CLI layer (`--prompt` kept):**
- `docs/INSTALL_FOR_AGENTS.md:73` — the `node "$AGY_ROOT/companion/agy-companion.mjs" ask --prompt "reply with OK"` fallback.
- The five `node ".../agy-companion.mjs" <mode> [flags] --prompt "…"` fences.
- The five skills' flag bullets, and `skills/jobs/SKILL.md`'s `continue --prompt "follow-up text"` (its siblings in that list are `status [job-id]`, `result [job-id]`, `cancel <job-id>`, `setup [--apply]` — all bare companion subcommands).
- `skills/ask/SKILL.md:10` `ask --prompt "reply with OK"` and `skills/staffer/SKILL.md:14` `staffer --prompt "generate a pixel-art…"` — bare companion subcommands under the same convention, each sitting directly above its own `node …` fence.
- `skills/reviewer/references/code-review.md`, `docs/REFERENCE.md` + `docs/REFERENCE.zh-CN.md` (flag table, Task text section, review examples, migration table, troubleshooting), `tests/README.md`, and all tests.

Each of the five SKILL.md files states the translation in one line of its invocation section — pass the user's text verbatim via `--prompt`, using `--prompt-file` / `--stdin` for long text. Both REFERENCE files open the Task text section with the same clarification.

State-facing docs (the REFERENCE body and the SKILL.md files) describe only the current interface, in present tense. The change narrative lives exclusively in `docs/releases/v0.4.5.md` and the REFERENCE **Migration from 0.4.4** sections, so a reader who never saw the old CLI does not learn the positional form from the interface docs.

## Tests

`node --test tests/*.test.mjs`: **110 tests, 110 pass, 0 fail** (89 before this change, all still green after the sweep to `--prompt` form).

New coverage pinning the design: opacity for a foreground `ask` **and** a background `review` (the issue's acceptance criterion), flag-like payloads via `--prompt-file` and `--stdin`, real flags around `--prompt` honored with a non-default `--timeout 90s` (review's default is 5m, so the assertion cannot pass vacuously), byte-exact prompt fidelity through quotes/newlines/double spaces, both source-conflict pairs, positional task text (a plain word and an empty string), packed one-big-string arguments, `--` having no special meaning, the four value-flag guards, `continue --prompt 'now check --check again'` reaching the state check rather than a flag error, migration flags still dying, and a management regression (`wait <id> --timeout 1s`, `status`, `setup --restrict review`).

Also verified: `node --check companion/agy-companion.mjs`, `git diff --check`, and a manual smoke against `tests/fake-agy.mjs` in a throwaway repo confirming the exact prompt bytes agy receives for each new case.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4wwbeDvXuCUVfRerQDdm7
